### PR TITLE
fix: downgrade rust toolchain version

### DIFF
--- a/msim/src/sim/runtime/mod.rs
+++ b/msim/src/sim/runtime/mod.rs
@@ -483,7 +483,8 @@ impl NodeHandle {
 
     /// Join the node.
     /// TODO: unimplemented
-    #[expect(clippy::result_unit_err)]
+    // TODO: add this line after upgrading to toolchain 1.81
+    //#[expect(clippy::result_unit_err)]
     pub fn join(self) -> Result<(), ()> {
         warn!("TODO: implement NodeHandle::join()");
         Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81"
+channel = "1.80.1"


### PR DESCRIPTION
Currently the iota simtest can't be run because the toolchain there is still 1.80.1, and therefore the expect keyword is not suppurted. We should downgrade an force merge ignoring clippy for now (it's a warning only anyway).

![grafik](https://github.com/user-attachments/assets/ddd95a85-c921-41d1-9631-d836bb426ba7)
